### PR TITLE
Fix Windows build when UNICODE macro is specified.

### DIFF
--- a/zinnia/mmap.h
+++ b/zinnia/mmap.h
@@ -112,8 +112,8 @@ template <class T> class Mmap {
       CHECK_CLOSE_FALSE(false) << "unknown open mode:" << filename;
     }
 
-    hFile = CreateFile(filename, mode1, FILE_SHARE_READ, 0,
-                       OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
+    hFile = CreateFileA(filename, mode1, FILE_SHARE_READ, 0,
+                        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
     CHECK_CLOSE_FALSE(hFile != INVALID_HANDLE_VALUE)
         << "CreateFile() failed: " << filename;
 


### PR DESCRIPTION
When UNICODE macro is specified, CreateFile is mapped to
CreateFileW rather than CreateFileA, which results in a
build error due to incompatible types.

We can support both cases by using CreateFileA explicitly.
