### PR TITLE
Include <iterator> for VC++2010 and later

### DIFF
--- a/zinnia/trainer.cpp
+++ b/zinnia/trainer.cpp
@@ -7,6 +7,7 @@
 //
 #include <vector>
 #include <iostream>
+#include <iterator>
 #include <fstream>
 #include <set>
 #include <string>


### PR DESCRIPTION
Without this we cannot build Zinnia with Visual C++ 2010
and later versions.
