### PR TITLE
Fix compile error of std::make_pair in C++11

### DIFF
--- a/zinnia/AUTHORS
+++ b/zinnia/AUTHORS
@@ -1,1 +1,2 @@
 Taku Kudo <taku@chasen.org>
+Google Inc. <*@google.com>

--- a/zinnia/trainer.cpp
+++ b/zinnia/trainer.cpp
@@ -104,7 +104,7 @@ class TrainerImpl: public Trainer {
     if (!fn) {
       return false;
     }
-    x_.push_back(std::make_pair<std::string, FeatureNode *>(y, fn));
+    x_.push_back(std::make_pair(y, fn));
     return true;
   }
 


### PR DESCRIPTION
std::make_pair is not designed to be used with explicit type
parameters.  In practice doing that can result in compile error
with Clang 3.4 on Ubuntu 14.04 when C++11 is enabled.

This CL removes explicit type parameters so that Zinnia can be
built even if C++11 is enabled.
