### PR TITLE
Introduce ZINNIA_STATIC_LIBRARY for Windows

### DIFF
--- a/zinnia/zinnia.h
+++ b/zinnia/zinnia.h
@@ -21,7 +21,9 @@ extern "C" {
 
 #ifdef _WIN32
 #include <windows.h>
-#  ifdef DLL_EXPORT
+#  if defined(ZINNIA_STATIC_LIBRARY)
+#    define ZINNIA_DLL_EXTERN
+#  elif defined(DLL_EXPORT)
 #    define ZINNIA_DLL_EXTERN  __declspec(dllexport)
 #  else
 #    define ZINNIA_DLL_EXTERN  __declspec(dllimport)


### PR DESCRIPTION
Currently `ZINNIA_DLL_EXTERN` macro defined in zinnia.h can only be either `__declspec(dllexport)` or `__declspec(dllimport)`, which results in a compile error for projects that want to use Zinnia as a static library.

With this CL, we can specify `ZINNIA_STATIC_LIBRARY` to build and use Zinnia as a static library on Windows.
